### PR TITLE
fix: handle wildcard '*' in MATTERMOST_CHANNELS configuration

### DIFF
--- a/deputy/models/config.py
+++ b/deputy/models/config.py
@@ -51,8 +51,17 @@ class MattermostConfig(BaseModel):
 
     def should_listen_to_channel(self, channel_name: str) -> bool:
         for pattern in self.channels:
-            if re.match(pattern, channel_name):
+            # Handle wildcard pattern '*' to match all channels
+            if pattern == "*":
                 return True
+
+            try:
+                if re.match(pattern, channel_name):
+                    return True
+            except re.error:
+                # If regex pattern is invalid, treat as literal string match
+                if pattern == channel_name:
+                    return True
         return False
 
 


### PR DESCRIPTION
## Summary
- Fixes the "nothing to repeat at position 0" regex error when using `MATTERMOST_CHANNELS=*`
- Adds explicit wildcard handling and robust regex error handling
- Includes comprehensive unit tests

## Changes Made
- **Enhanced channel filtering logic** in `deputy/models/config.py`
  - Added special case handling for `*` wildcard pattern
  - Added try/catch around regex matching with literal string fallback
- **Added unit tests** in `tests/test_bot.py`
  - Test wildcard pattern matching all channels
  - Test invalid regex patterns falling back to literal matching

## Test Plan
- [x] All existing tests pass
- [x] New wildcard functionality tested
- [x] Invalid regex patterns handled gracefully
- [x] Code formatted with ruff

## Related Issue
Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)