### PR TITLE
feat: add inline issue creation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ docker-compose down        # Stop server
 **Important**: 
 - Always run `uv run ruff check` and `uv run ruff format` before committing and after completing any coding task to ensure code quality
 - Write unit tests with pytest for any new functionality added to the codebase, following existing test patterns in the `tests/` directory
+- Write concise commit messages following the pattern: `type: brief description` (e.g., `feat: add inline issue creation`, `fix: handle wildcard channels`)
 
 ## Architecture
 

--- a/tests/test_bot_advanced_commands.py
+++ b/tests/test_bot_advanced_commands.py
@@ -268,5 +268,5 @@ class TestBotAdvancedCommands:
 
         help_message = bot._get_help_message()
 
-        assert "respond with `yes` or `no` when prompted" in help_message
+        assert "Respond with `yes` or `no` when prompted" in help_message
         assert "`create-issue`" in help_message


### PR DESCRIPTION
## Summary
- Add support for creating GitHub issues directly from command description
- Maintains backward compatibility with existing thread analysis functionality
- Includes comprehensive testing and documentation updates

## New Features
**Dual Mode Issue Creation:**
- `@deputy create-issue <description>` - Creates issue directly from provided text
- `@deputy create-issue` - Continues to analyze current thread (existing behavior)

**Enhanced User Experience:**
- Updated help message with clear examples of both usage patterns
- Improved confidence thresholds for direct descriptions (0.2 vs 0.3 for threads)
- Consistent duplicate detection and confirmation flow for both modes

## Changes Made
- **Enhanced command handling** in `deputy/bot.py`
  - Modified `_handle_create_issue_command` to detect and route between modes
  - Added `_create_issue_from_description` for direct issue creation
  - Refactored existing logic into `_create_issue_from_thread`
- **Updated documentation** 
  - Enhanced help message with examples and usage notes
  - Added commit message guidelines to CLAUDE.md
- **Comprehensive testing**
  - Added tests for inline description functionality
  - Added tests for low confidence handling
  - Updated existing tests for new help message format

## Test Plan
- [x] All existing tests pass (backward compatibility maintained)
- [x] New inline functionality tested with various scenarios
- [x] Low confidence descriptions handled gracefully
- [x] Help message includes both usage patterns
- [x] Code quality verified with ruff

## Examples
```bash
# Direct issue creation
@deputy create-issue Login button not working on mobile Safari

# Thread analysis (existing)
@deputy create-issue
```

Both modes support duplicate detection and require `yes`/`no` confirmation when similar issues are found.

🤖 Generated with [Claude Code](https://claude.ai/code)